### PR TITLE
yank: add a comment to set allow-passthrough in tmux.conf

### DIFF
--- a/bin/yank
+++ b/bin/yank
@@ -17,6 +17,11 @@
 # by copying directly to the X11 clipboard if a $DISPLAY server is available;
 # otherwise, it emits a warning (on stderr) about the number of bytes dropped.
 #
+# For this script to work properly, allow it to bypass tmux (using the Ptmux;
+# escape sequence) by enabling allow-passthrough in your tmux.conf:
+#
+#   set-window-option -g allow-passthrough on
+#
 # See http://en.wikipedia.org/wiki/Base64 for the 4*ceil(n/3) length formula.
 # See http://sourceforge.net/p/tmux/mailman/message/32221257 for copy limits.
 # See http://sourceforge.net/p/tmux/tmux-code/ci/a0295b4c2f6 for DCS in tmux.


### PR DESCRIPTION
Not having `allow-passthrough on` set in `.tmux.conf` was the cause of `yank` not working for me. I note that you have this set in your `.tmux.conf`, but it's not mentioned in this file or on your site. You may want to update your site accordingly.

On a related note, I noticed that the tmux escape sequence doesn't even seem to be necessary. I can alternatively comment out the line `test -n "$TMUX" -o -z "${TERM##screen*}" && esc="\033Ptmux;\033$esc\033\\"`, and everything works fine (including without this configuration change to `.tmux.conf`) with the following versions I've tested:

macOS 12.4 - 13.3.1:
iTerm2 3.4.16 - 3.4.19
OpenSSH 8.6p1 - 9.0p1
tmux 3.3a

Ubuntu 20.04 - 22.04.2:
OpenSSH 8.2p1 - 8.9p1
tmux 3.2 - 3.3a

(Specifically when SSH'ing from macOS to Ubuntu, but not the other way around, since GNOME Terminal 3.36.2 on Ubuntu still doesn't support OSC52.)

Unless you're knowingly supporting a (perhaps older?) version of tmux that requires `allow-passthrough on`, you may want to consider testing whether the `Ptmux;` escape sequence is still necessary on your end, and if not, simply remove it.

Thanks for sharing your awesome work!